### PR TITLE
set mongodb.available on conn string availability

### DIFF
--- a/requires.py
+++ b/requires.py
@@ -38,6 +38,7 @@ class MongoDBClient(RelationBase):
     def changed(self):
         if self.connection_string():
             self.set_state('{relation_name}.database.available')
+            self.set_state('{relation_name}.available')
         else:
             self.set_state('{relation_name}.removed')
 


### PR DESCRIPTION
Set a state with a more uniform name - {relation-name}.available is more
intuitive and in line with other states while .database.available is only
apparent after looking at requires.py.