### PR TITLE
Cleanup reactive states handling and expose replset relation parameter

### DIFF
--- a/requires.py
+++ b/requires.py
@@ -40,7 +40,8 @@ class MongoDBClient(RelationBase):
             self.set_state('{relation_name}.database.available')
             self.set_state('{relation_name}.available')
         else:
-            self.set_state('{relation_name}.removed')
+            self.remove_state('{relation_name}.database.available')
+            self.remove_state('{relation_name}.available')
 
     @hook('{requires:mongodb}-relation-{broken,departed}')
     def broken_departed(self):
@@ -48,7 +49,7 @@ class MongoDBClient(RelationBase):
 
     @hook('{requires:mongodb}-relation-broken')
     def broken(self):
-        self.set_state('{relation_name}.removed')
+        self.remove_state('{relation_name}.connected')
 
     def connection_string(self):
         """

--- a/requires.py
+++ b/requires.py
@@ -28,7 +28,7 @@ class MongoDBClient(RelationBase):
 
     # These remote data fields will be automatically mapped to accessors
     # with a basic documentation string provided.
-    auto_accessors = ['hostname', 'port']
+    auto_accessors = ['hostname', 'port', 'replset']
 
     @hook('{requires:mongodb}-relation-joined')
     def joined(self):
@@ -42,6 +42,11 @@ class MongoDBClient(RelationBase):
         else:
             self.remove_state('{relation_name}.database.available')
             self.remove_state('{relation_name}.available')
+
+        if self.replset():
+            self.set_state('{relation_name}.replset.available')
+        else:
+            self.remove_state('{relation_name}.replset.available')
 
     @hook('{requires:mongodb}-relation-{broken,departed}')
     def broken_departed(self):


### PR DESCRIPTION
This PR is attempts to make state handling better by deleting set_state("*.removed") calls and adding calls to actually remove .available states.

The second patch exposes the replset parameter of a relation which is already present in the mongodb charm code:
https://bazaar.launchpad.net/~charmers/charms/trusty/mongodb/trunk/view/head:/hooks/hooks.py#L1141

Some applications (like zaqar) require replicated or sharded configurations only and do not work with standalone instances which is why the change is needed.